### PR TITLE
feat(#26): add polling enabled/disabled toggle to HomeScreen

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:permission_handler/permission_handler.dart';
+import 'package:workmanager/workmanager.dart';
 
 import 'package:oping/models/chapter.dart';
 import 'package:oping/services/chapter_storage_service.dart';
@@ -19,6 +20,7 @@ class _HomeScreenState extends State<HomeScreen> {
   DateTime? _lastChecked;
   bool _isLoading = true;
   bool _isChecking = false;
+  bool _pollingEnabled = true;
   String? _errorMessage;
 
   final _mangaDex = MangaDexService();
@@ -29,6 +31,28 @@ class _HomeScreenState extends State<HomeScreen> {
     super.initState();
     _requestNotificationPermission();
     _loadData();
+    _loadPollingState();
+  }
+
+  Future<void> _loadPollingState() async {
+    final enabled = await _storage.getPollingEnabled();
+    if (mounted) setState(() => _pollingEnabled = enabled);
+  }
+
+  Future<void> _setPollingEnabled(bool enabled) async {
+    await _storage.savePollingEnabled(enabled);
+    if (enabled) {
+      await Workmanager().registerPeriodicTask(
+        WorkerTask.taskName,
+        WorkerTask.taskName,
+        frequency: const Duration(hours: 1),
+        constraints: Constraints(networkType: NetworkType.connected),
+        existingWorkPolicy: ExistingWorkPolicy.replace,
+      );
+    } else {
+      await Workmanager().cancelByUniqueName(WorkerTask.taskName);
+    }
+    if (mounted) setState(() => _pollingEnabled = enabled);
   }
 
   Future<void> _requestNotificationPermission() async {
@@ -152,6 +176,8 @@ class _HomeScreenState extends State<HomeScreen> {
         if (_errorMessage != null) _buildErrorCard(theme) else if (_latestChapter != null) ChapterCard(chapter: _latestChapter!),
         const SizedBox(height: 12),
         _buildLastChecked(theme),
+        const SizedBox(height: 16),
+        _buildPollingToggle(theme),
         const SizedBox(height: 80),
       ],
     );
@@ -209,6 +235,24 @@ class _HomeScreenState extends State<HomeScreen> {
         color: theme.colorScheme.onSurfaceVariant,
       ),
       textAlign: TextAlign.center,
+    );
+  }
+
+  Widget _buildPollingToggle(ThemeData theme) {
+    return Card(
+      child: SwitchListTile(
+        title: const Text('Background polling'),
+        subtitle: Text(
+          _pollingEnabled ? 'Checks for new chapters every hour' : 'Notifications paused',
+          style: theme.textTheme.bodySmall,
+        ),
+        secondary: Icon(
+          _pollingEnabled ? Icons.notifications_active : Icons.notifications_off,
+          color: _pollingEnabled ? theme.colorScheme.primary : theme.colorScheme.onSurfaceVariant,
+        ),
+        value: _pollingEnabled,
+        onChanged: _setPollingEnabled,
+      ),
     );
   }
 

--- a/lib/services/chapter_storage_service.dart
+++ b/lib/services/chapter_storage_service.dart
@@ -3,6 +3,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 class ChapterStorageService {
   static const String _lastChapterKey = 'last_seen_chapter_number';
   static const String _lastCheckedKey = 'last_checked_timestamp';
+  static const String _pollingEnabledKey = 'polling_enabled';
 
   Future<double> getLastSeenChapter() async {
     final prefs = await SharedPreferences.getInstance();
@@ -20,5 +21,15 @@ class ChapterStorageService {
     final raw = prefs.getString(_lastCheckedKey);
     if (raw == null) return null;
     return DateTime.tryParse(raw);
+  }
+
+  Future<bool> getPollingEnabled() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_pollingEnabledKey) ?? true;
+  }
+
+  Future<void> savePollingEnabled(bool enabled) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_pollingEnabledKey, enabled);
   }
 }


### PR DESCRIPTION
## Summary
- `ChapterStorageService`: added `getPollingEnabled()` / `savePollingEnabled()` backed by SharedPreferences (default: true)
- `HomeScreen`: `SwitchListTile` card showing current polling state; toggling off calls `Workmanager().cancelByUniqueName()`, toggling on re-registers with `ExistingWorkPolicy.replace`
- State persists across app restarts

## Test plan
- [x] `flutter test` — 18 tests pass
- [x] `flutter analyze` — no issues

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)